### PR TITLE
Support for the `set` keyword

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nunjucks-pre-lexer",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nunjucks-pre-lexer",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A tool for identifying and fetching the data that a Nunjucks template expects.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/create-object-lookup-string.ts
+++ b/src/create-object-lookup-string.ts
@@ -6,7 +6,11 @@ function getValues (node: Node, pieces: string[] = []): string[] {
   }
 
   if ('value' in node) {
-    pieces.unshift(node.value)
+    if (typeof node.value === 'string') {
+      pieces.unshift(node.value)
+    } else {
+      return getValues(node.value)
+    }
   }
 
   // LookupVal and nested object use `node.target`

--- a/src/parse-children.ts
+++ b/src/parse-children.ts
@@ -4,8 +4,9 @@ import { Node } from './types'
  * We care about:
  * LookupVal: `{{ foo.bar }}`, getting a property in an object
  * FunCall: `{{ foo() }}`, a function as a variable
+ * Set: `{% set key = foo.bar %}`, setting a variable in a template
  */
-const IMPORTANT_TYPES = ['LookupVal', 'FunCall', 'If', 'For']
+const IMPORTANT_TYPES = ['LookupVal', 'FunCall', 'If', 'For', 'Set']
 
 export function parseChildren (children: Node[], nodes: Node[] = []) {
   for (const child of children) {

--- a/src/parsers/LookupVal.ts
+++ b/src/parsers/LookupVal.ts
@@ -2,21 +2,7 @@ import get from 'get-value'
 import set from 'set-value'
 import { createObjectLookupString } from '../create-object-lookup-string'
 import { Node } from '../types'
-import { FunCall } from './FunCall'
-
-async function walkNode (schema: object, node: Node, data: any): Promise<any> {
-  if (node.typename === 'FunCall') {
-    await FunCall(schema, node, data)
-  }
-
-  if (node.target) {
-    return walkNode(schema, node.target, data)
-  }
-
-  if (node.name) {
-    return walkNode(schema, node.name, data)
-  }
-}
+import { walkNode } from '../walk-node'
 
 export async function LookupVal (schema: object, node: Node, data: any) {
   await walkNode(schema, node, data)

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -5,11 +5,13 @@ import { LookupVal } from './LookupVal'
 interface Parsers {
   FunCall: (schema: object, node: Node, data: any) => any
   LookupVal: (schema: object, node: Node, data: any) => any
+  Set: (schema: object, node: Node, data: any) => any
 }
 
 export type ParserKeys = keyof Parsers
 
 export const parsers: Parsers = {
   FunCall,
-  LookupVal
+  LookupVal,
+  Set: LookupVal // Set and LookupVal use the same logic
 }

--- a/src/walk-node.ts
+++ b/src/walk-node.ts
@@ -1,0 +1,16 @@
+import { FunCall } from './parsers/FunCall'
+import { Node } from './types'
+
+export async function walkNode (schema: object, node: Node, data: any): Promise<any> {
+  if (node.typename === 'FunCall') {
+    await FunCall(schema, node, data)
+  }
+
+  if (node.target) {
+    return walkNode(schema, node.target, data)
+  }
+
+  if (node.name) {
+    return walkNode(schema, node.name, data)
+  }
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -137,4 +137,11 @@ describe('lexer', () => {
     const data = await lexer(obj, src)
     expect(data.lib.test().example()).toEqual({ foo: true })
   })
+
+  it('gets the values in a `set` operator', async () => {
+    const src = '{% set example = lib.test %}'
+    const obj = { lib: { test: true } }
+    const data = await lexer(obj, src)
+    expect(data.lib.test).toBe(true)
+  })
 })


### PR DESCRIPTION
Adds support for the `set` keyword; see this passing test:

```js
  it('gets the values in a `set` operator', async () => {
    const src = '{% set example = lib.test %}'
    const obj = { lib: { test: true } }
    const data = await lexer(obj, src)
    expect(data.lib.test).toBe(true)
  })
```

Closes #1 